### PR TITLE
Run "cf" inside Docker

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -22,6 +22,9 @@ steps:
     concurrency: 1
     concurrency_group: "cf-push"
     plugins:
+      seek-oss/aws-sm#v2.0.0:
+        env:
+          CF_PASSWORD: arn:aws:secretsmanager:us-east-1:868593321044:secret:pipelines/pws/drnic/cf-password-dUL5fd
       ${BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
         api: https://api.run.pivotal.io
         username: drnic@starkandwayne.com

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -25,6 +25,7 @@ steps:
       ${BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
         api: https://api.run.pivotal.io
         username: drnic@starkandwayne.com
+        password_env: PWS_CF_PASSWORD_DRNIC
         organization: starkandwayne
         space: buildkite-plugin-tests
         appname: buildkite-plugin-test

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -19,8 +19,6 @@ steps:
   - wait
 
   - label: ":cloudfoundry: deploy"
-    agents:
-      cf-cli: true
     concurrency: 1
     concurrency_group: "cf-push"
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -28,7 +28,6 @@ steps:
       ${BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
         api: https://api.run.pivotal.io
         username: drnic@starkandwayne.com
-        password_env: PWS_CF_PASSWORD_DRNIC
         organization: starkandwayne
         space: buildkite-plugin-tests
         appname: buildkite-plugin-test

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,3 +7,8 @@ RUN CF_CLI_VERSION=6.50.0 && \
   curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_CLI_VERSION}&source=github-rel" | tar -C /usr/bin -xvz cf
 
 WORKDIR /workspace
+
+RUN addgroup -g 100000 buildkite && \
+  adduser -G buildkite -u 100000 -D buildkite
+
+USER buildkite

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,3 @@ RUN CF_CLI_VERSION=6.50.0 && \
   curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_CLI_VERSION}&source=github-rel" | tar -C /usr/bin -xvz cf
 
 WORKDIR /workspace
-
-RUN addgroup -g 100000 buildkite && \
-  adduser -G buildkite -u 100000 -D buildkite
-
-USER buildkite

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:3.11
+
+RUN apk add --no-cache curl bash jq
+
+# install 'cf' into /usr/bin/cf
+RUN CF_CLI_VERSION=6.50.0 && \
+  curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_CLI_VERSION}&source=github-rel" | tar -C /usr/bin -xvz cf
+
+WORKDIR /workspace

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ The plugin will annotate the Buildkite build with the URL for the application, a
 
 ![annotations](https://p198.p4.n0.cdn.getcloudapp.com/items/v1urO4Dm/buildkite-cf-deploy-plugin-annotations.png?v=5ddf0b36153c564d146ade020db0abc9)
 
+The plugin requires the Docker Daemon and `docker` CLI to be available.
+
 ## Usage
 
 Sample usage with minimum required arguments:

--- a/hooks/command
+++ b/hooks/command
@@ -10,6 +10,9 @@ env | sort
 CF_APPNAME=$BUILDKITE_PLUGIN_CLOUDFOUNDRY_DEPLOY_APPNAME
 CF_APPNAME_VENERABLE="${CF_APPNAME}-venerable"
 
+[[ -n "${BUILDKITE_PLUGIN_CLOUDFOUNDRY_DEPLOY_PASSWORD_ENV:-}" ]] && {
+  export CF_PASSWORD="${!BUILDKITE_PLUGIN_CLOUDFOUNDRY_DEPLOY_PASSWORD_ENV:?required}"
+}
 : "${CF_PASSWORD:?required for 'cf auth'}"
 
 # From https://buildkite.com/docs/pipelines/links-and-images-in-log-output#links
@@ -74,10 +77,6 @@ trap buildkite_agent_docker_cleanup ERR EXIT SIGQUIT
       exit 1
     fi
   fi
-
-  # [[ -n "${BUILDKITE_PLUGIN_CLOUDFOUNDRY_DEPLOY_PASSWORD_ENV:-}" ]] && {
-  #   export CF_PASSWORD="${!BUILDKITE_PLUGIN_CLOUDFOUNDRY_DEPLOY_PASSWORD_ENV}"
-  # }
 
   echo "--- :cloudfoundry: Running cf auth"
   echo -ne '\033[90m$\033[0m cf auth ' >&2

--- a/hooks/command
+++ b/hooks/command
@@ -36,16 +36,8 @@ function docker_run {
     --workdir /workspace \
     "${DOCKER_RUN:-starkandwayne/cloudfoundry-deploy-buildkite-plugin}" \
     "$@"
-
-  buildkite_agent_cleanup
 )
 }
-
-function buildkite_agent_cleanup {
-  chown -hR buildkite:buildkite "$PWD"
-}
-trap buildkite_agent_cleanup ERR EXIT SIGQUIT
-
 
 (
   # cf api

--- a/hooks/command
+++ b/hooks/command
@@ -121,7 +121,7 @@ trap enable_buildkite_agent_cleanup EXIT
         docker_run cf delete "$CF_APPNAME_VENERABLE" -f
       fi
 
-      cf rename "$CF_APPNAME" "$CF_APPNAME_VENERABLE"
+      docker_run cf rename "$CF_APPNAME" "$CF_APPNAME_VENERABLE"
     else
       echo "--> App $CF_APPNAME #0 instance state '$container0_status', deleting it"
 

--- a/hooks/command
+++ b/hooks/command
@@ -42,7 +42,7 @@ function docker_run {
 function enable_buildkite_agent_cleanup {
   chown -hR buildkite:buildkite "$PWD"
 }
-trap enable_buildkite_agent_cleanup EXIT
+trap enable_buildkite_agent_cleanup ERR EXIT SIGQUIT
 
 
 (

--- a/hooks/command
+++ b/hooks/command
@@ -10,25 +10,6 @@ env | sort
 CF_APPNAME=$BUILDKITE_PLUGIN_CLOUDFOUNDRY_DEPLOY_APPNAME
 CF_APPNAME_VENERABLE="${CF_APPNAME}-venerable"
 
-export CF_HOME=$PWD/tmp/home
-mkdir -p "$CF_HOME"
-
-export CF_BIN=$CF_HOME/bin
-mkdir -p "$CF_BIN"
-export PATH=$CF_BIN:$PATH
-
-(
-  [[ -x "$(command -v cf)" ]] || {
-    echo "--- :cloudfoundry: Downloading cf cli"
-    CF_CLI_VERSION=${CF_CLI_VERSION:-6.50.0}
-    curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_CLI_VERSION}&source=github-rel" | tar -C "${CF_BIN}" -xvz cf
-  }
-  [[ -x "$(command -v jq)" ]] || {
-    echo "--- :json: Downloading jq cli"
-    curl -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -o "${CF_BIN}/jq"
-  }
-)
-
 # From https://buildkite.com/docs/pipelines/links-and-images-in-log-output#links
 function inline_link_v2 {
   LINK=$(printf "url='%s'" "$1")
@@ -43,6 +24,8 @@ function inline_link_v2 {
 
 function docker_run {
 (
+  mkdir -p tmp/home
+
   docker container run \
     -v "$PWD:/workspace" \
     -e CF_HOME=/workspace/tmp/home \

--- a/hooks/command
+++ b/hooks/command
@@ -10,6 +10,8 @@ env | sort
 CF_APPNAME=$BUILDKITE_PLUGIN_CLOUDFOUNDRY_DEPLOY_APPNAME
 CF_APPNAME_VENERABLE="${CF_APPNAME}-venerable"
 
+: "${CF_PASSWORD:?required for 'cf auth'}"
+
 # From https://buildkite.com/docs/pipelines/links-and-images-in-log-output#links
 function inline_link_v2 {
   LINK=$(printf "url='%s'" "$1")

--- a/hooks/command
+++ b/hooks/command
@@ -39,6 +39,12 @@ function docker_run {
 )
 }
 
+function enable_buildkite_agent_cleanup {
+  chown -hR buildkite:buildkite "$PWD"
+}
+trap enable_buildkite_agent_cleanup EXIT
+
+
 (
   # cf api
   args=()

--- a/hooks/command
+++ b/hooks/command
@@ -41,6 +41,19 @@ function inline_link_v2 {
   printf '\033]1339;%s\a\n' "$LINK"
 }
 
+function docker_run {
+(
+  docker container run \
+    -v "$PWD:/workspace" \
+    -e CF_HOME=/workspace/tmp/home \
+    -e CF_PASSWORD \
+    --label "cloudfoundry-deploy-buildkite-plugin-version=$plugin_version" \
+    --workdir /workspace \
+    "${DOCKER_RUN:-starkandwayne/cloudfoundry-deploy-buildkite-plugin}" \
+    "$@"
+)
+}
+
 (
   # cf api
   args=()
@@ -57,7 +70,7 @@ function inline_link_v2 {
   printf "%q " "${args[@]}"
   echo
 
-  cf api "${args[@]}"
+  docker_run cf api "${args[@]}"
 )
 
 (
@@ -83,7 +96,7 @@ function inline_link_v2 {
   printf "%q " "${args[@]}"
   echo
 
-  cf auth "${args[@]}"
+  docker_run cf auth "${args[@]}"
 )
 
 (
@@ -99,29 +112,29 @@ function inline_link_v2 {
   printf "%q " "${args[@]}"
   echo
 
-  cf target "${args[@]}"
+  docker_run cf target "${args[@]}"
 )
 
 [[ -z "${BUILDKITE_PLUGIN_CLOUDFOUNDRY_DEPLOY_SKIP_ZERO_DOWNTIME:-}" ]] && {
 (
   echo "--- :cloudfoundry: Renaming app $CF_APPNAME -> $CF_APPNAME_VENERABLE (if necessary)"
-  if cf app "$CF_APPNAME" 2>/dev/null >/dev/null ; then
+  if docker_run cf app "$CF_APPNAME" 2>/dev/null >/dev/null ; then
     echo "--> Found app $CF_APPNAME"
 
-    container0_status=$(cf app "$CF_APPNAME" 2>/dev/null | grep "^#0" | awk '{print $2}')
+    container0_status=$(docker_run cf app "$CF_APPNAME" 2>/dev/null | grep "^#0" | awk '{print $2}')
     if [[ "${container0_status:-unknown}" == "running" ]]; then
       echo "--> Confirmed app $CF_APPNAME #0 instance 'running'"
 
-      if cf app "$CF_APPNAME_VENERABLE" 2>/dev/null >/dev/null ; then
+      if docker_run cf app "$CF_APPNAME_VENERABLE" 2>/dev/null >/dev/null ; then
         echo "--> Found app $CF_APPNAME_VENERABLE; deleting it."
-        cf delete "$CF_APPNAME_VENERABLE" -f
+        docker_run cf delete "$CF_APPNAME_VENERABLE" -f
       fi
 
       cf rename "$CF_APPNAME" "$CF_APPNAME_VENERABLE"
     else
       echo "--> App $CF_APPNAME #0 instance state '$container0_status', deleting it"
 
-      cf delete "$CF_APPNAME" -f
+      docker_run cf delete "$CF_APPNAME" -f
     fi
   else
     echo "--> App $CF_APPNAME does not exist, nothing to do."
@@ -137,9 +150,9 @@ function inline_link_v2 {
   }
 
   [[ -n "${BUILDKITE_PLUGIN_CLOUDFOUNDRY_DEPLOY_VARS:-}" ]] && {
-    vars_yml=$(mktemp -t "vars.yml")
+    vars_yml=tmp/vars.yml
     echo "${BUILDKITE_PLUGIN_CLOUDFOUNDRY_DEPLOY_VARS}" > "$vars_yml"
-    args+=("--vars-file" "${vars_yml}")
+    args+=("--vars-file" tmp/vars.yml)
   }
 
   echo "--- :cloudfoundry: Running cf push"
@@ -149,15 +162,15 @@ function inline_link_v2 {
   printf "%q " "${args[@]}"
   echo
 
-  cf push "${args[@]}"
+  docker_run cf push "${args[@]}"
 )
 
-app_guid="$(cf app "$BUILDKITE_PLUGIN_CLOUDFOUNDRY_DEPLOY_APPNAME" --guid)"
-app_url="/v3/apps/${app_guid}"
+app_guid="$(docker_run cf app "$BUILDKITE_PLUGIN_CLOUDFOUNDRY_DEPLOY_APPNAME" --guid)"
 
 (
   args=()
-  args+=("$app_url" "-X" "PATCH" "-d")
+  args+=("/v3/apps/${app_guid}" "-X" "PATCH" "-d")
+  echo "args" "${args[@]}"
 
   commit_sha="$(git rev-parse --short HEAD)"
   origin_url="$(git config remote.origin.url)"
@@ -171,7 +184,7 @@ app_url="/v3/apps/${app_guid}"
 
   [[ -n "${BUILDKITE_PROJECT_SLUG:-}" ]] && {
     buildkite_url="https://buildkite.com/$BUILDKITE_PROJECT_SLUG/builds/$BUILDKITE_BUILD_NUMBER#$BUILDKITE_BUILD_ID"
-    annotation_json=$(jq -rc --arg annotation "buildkite-url"    --arg value "$buildkite_url" '.[$annotation] = $value' <<< "$annotation_json")
+    annotation_json=$(jq -rc --arg annotation "buildkite-url" --arg value "$buildkite_url" '.[$annotation] = $value' <<< "$annotation_json")
   }
 
   patch_json=$(jq -src '.[0] * .[1]' \
@@ -186,43 +199,43 @@ app_url="/v3/apps/${app_guid}"
   # Print all the arguments, with a space after, properly shell quoted
   printf "%q " "${args[@]}"
   echo
-  cf curl "${args[@]}"
+  docker_run cf curl "${args[@]}"
 
 )
 
 [[ -z "${BUILDKITE_PLUGIN_CLOUDFOUNDRY_DEPLOY_SKIP_ZERO_DOWNTIME:-}" ]] && {
 (
   echo "--- :cloudfoundry: Clean up venerable app"
-  if cf app "$CF_APPNAME" 2>/dev/null >/dev/null ; then
+  if docker_run cf app "$CF_APPNAME" 2>/dev/null >/dev/null ; then
     echo "--> Confirmed found app $CF_APPNAME"
 
-    container0_status=$(cf app "$CF_APPNAME" 2>/dev/null | grep "^#0" | awk '{print $2}')
+    container0_status=$(docker_run cf app "$CF_APPNAME" 2>/dev/null | grep "^#0" | awk '{print $2}')
     if [[ "${container0_status:-unknown}" == "running" ]]; then
       echo "--> Confirmed #0 instance running"
 
       if cf app "$CF_APPNAME_VENERABLE" 2>/dev/null >/dev/null ; then
         echo "--> Found app $CF_APPNAME_VENERABLE; deleting it."
-        cf delete "$CF_APPNAME_VENERABLE" -f
+        docker_run cf delete "$CF_APPNAME_VENERABLE" -f
       fi
     fi
   fi
 )
 }
 
-DEPLOYED_URL=https://$(cf curl "/v3/apps/${app_guid}/routes" | jq -r ".resources[0].url")
+DEPLOYED_URL=https://$(docker_run cf curl "/v3/apps/${app_guid}/routes" | jq -r ".resources[0].url")
 export DEPLOYED_URL
 (
   cat <<EOF | buildkite-agent annotate --context cf-app-status
 Initial status of application:
 
 \`\`\`plain
-$(cf app "$CF_APPNAME")
+$(docker_run cf app "$CF_APPNAME")
 \`\`\`
 
 Labels and annotations added to application:
 
 \`\`\`json
-$(cf curl "/v3/apps/${app_guid}" | jq -r ".metadata")
+$(docker_run cf curl "/v3/apps/${app_guid}" | jq -r ".metadata")
 \`\`\`
 EOF
 

--- a/hooks/command
+++ b/hooks/command
@@ -36,13 +36,15 @@ function docker_run {
     --workdir /workspace \
     "${DOCKER_RUN:-starkandwayne/cloudfoundry-deploy-buildkite-plugin}" \
     "$@"
+
+  buildkite_agent_cleanup
 )
 }
 
-function enable_buildkite_agent_cleanup {
+function buildkite_agent_cleanup {
   chown -hR buildkite:buildkite "$PWD"
 }
-trap enable_buildkite_agent_cleanup ERR EXIT SIGQUIT
+trap buildkite_agent_cleanup ERR EXIT SIGQUIT
 
 
 (

--- a/hooks/command
+++ b/hooks/command
@@ -39,6 +39,11 @@ function docker_run {
 )
 }
 
+function buildkite_agent_docker_cleanup {
+  docker_run rm -rf /workspace/tmp
+}
+trap buildkite_agent_docker_cleanup ERR EXIT SIGQUIT
+
 (
   # cf api
   args=()
@@ -155,7 +160,6 @@ app_guid="$(docker_run cf app "$BUILDKITE_PLUGIN_CLOUDFOUNDRY_DEPLOY_APPNAME" --
 (
   args=()
   args+=("/v3/apps/${app_guid}" "-X" "PATCH" "-d")
-  echo "args" "${args[@]}"
 
   commit_sha="$(git rev-parse --short HEAD)"
   origin_url="$(git config remote.origin.url)"

--- a/plugin.yml
+++ b/plugin.yml
@@ -2,8 +2,7 @@ name: "Cloud Foundry Deploy"
 description: Deploys your application to Cloud Foundry
 author: https://github.com/starkandwayne
 requirements:
-  - bash
-  - cf
+  - docker
 configuration:
   properties:
     api:


### PR DESCRIPTION
Rather than expect host to have `cf` and `jq` installed, defer all `cf` commands to individual `docker container run` commands.

Note, `docker run` runs as `root`, so we trap the exit of the `hooks/command` and cleanse the `tmp/home/.cf` folder that is created as root user; else a buildkite-agent might not be able to delete the folder during cleanup.

This PR also fixes support for `.password_env` to describe which env var contains `cf auth` password.

This PR also switches the `pipeline.yml` to use AWS SecretsManager for the `cf auth` password being used for testing.